### PR TITLE
Deleting wrong dialog

### DIFF
--- a/data/maps/RustboroCity/scripts.inc
+++ b/data/maps/RustboroCity/scripts.inc
@@ -1313,10 +1313,7 @@ RustboroCity_Text_IdBetterGetBackToWork: @ 81E2464
 
 RustboroCity_Text_YouCanHave2On2Battle: @ 81E249D
 	.string "Did you know this?\p"
-	.string "You can have a 2-on-2 battle even\n"
-	.string "if you're not with another TRAINER.\p"
 	.string "If you catch the eyes of two TRAINERS\n"
-	.string "when you have two or more POKéMON,\l"
 	.string "they'll both challenge you.\p"
 	.string "Don't you think it'd be cool if you\n"
 	.string "could beat two TRAINERS by yourself?$"


### PR DESCRIPTION
Due to the modifications made to the original game, some dialogs of the NPCs give wrong information. Here is a list of all the dialogs that need to be deleted/changed according to the new functionalities:

#### OldaleTown_House1
- [ ] Woman: Change which pokémon will fight first a battle (The first two pokémon in your party.)
#### Route123_BerryMastersHoute
- [ ] BerryMaster: Change the flower shop location (Route 123)
#### RustboroCity
- [ ] Boy1: Delete dialogs which give grong information about double battles.
- [ ] LittleBoy: Change the way the pokémon change their shape. (Getting along very well with their trainer.)
- [ ] Man2: Change the whole dialog since it is related to pokémon trading.
#### RustboroCity_House1
- [ ] Trader: Change the whole dialog since it is a pokémon trade.
#### RustboroCity_PokemonCenter_1F
- [ ] Girl: Change the dialog since HM Cut won't be given by the next house's man.
#### RustboroCity_PokemonSchool
- [ ] Scott: Change the dialog about to have a pokémon learn Cut move (To get Cut move.) since a pokémon compatible with it can use it without having to learn it. Also, the dialog about someone who has Cut in the town. (This will be done according to the decision taken about HMs.)

### This list will be updated as wrong dialogs come or get fixed.