### PR TITLE
Feature: NPC trainer mons evolution.

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -1789,6 +1789,7 @@ static u8 CreateNPCTrainerParty(struct Pokemon *party, u16 trainerNum, bool8 fir
     u8 fixedLvl = 1;
     u8 baseLvl = 1;
     u8 monLvl = 1;
+    u8 monFriendship;
     u16 evoSpecies = SPECIES_NONE;
     const struct TrainerMonNoItemDefaultMoves *noItemDefaultMovesData = gTrainers[trainerNum].party.NoItemDefaultMoves;
     const struct TrainerMonNoItemCustomMoves *monNoItemCustomMovesData = gTrainers[trainerNum].party.NoItemCustomMoves;
@@ -1889,9 +1890,11 @@ static u8 CreateNPCTrainerParty(struct Pokemon *party, u16 trainerNum, bool8 fir
             personalityValue += nameHash << 8;
             fixedIV = fixedIV * 31 / 255;
             monLvl = monLvl > fixedLvl ? monLvl : fixedLvl;
+            monFriendship = ESTIMATED_FRIENDSHIP(monLvl);
             do
             {
                 CreateMon(&party[i], evoSpecies, monLvl, fixedIV, TRUE, personalityValue, OT_ID_RANDOM_NO_SHINY, 0);
+                SetMonData(&party[i], MON_DATA_FRIENDSHIP, &monFriendship);
                 evoSpecies = GetEvolutionTargetSpecies(&party[i], 0, 0);
             }
             while (evoSpecies != SPECIES_NONE);

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -299,8 +299,11 @@ static u16 GetCurrentMapWildMonHeaderId(void)
                 i += alteringCaveId;
                 return i;
             }
-            if ((i == 0 && IsDayTime()) || (i == 1 && IsNightTime()))
+            if (IsDayTime()) {
                 return i;
+            } 
+            if (IsNightTime())
+                return i + 1;
         }
     }
 


### PR DESCRIPTION
### Description
This feature allows mons of NPC trainers evolve if they meets the evolution requirements. For that propose, all mons of NPC trainers will have a friendship value equals to the estimated for their current level.

### Proposed changes
<!--- List the changes you are making. Mark them as you get them done. -->
- [x] Implement basic evolutions for NPC trainers.
