### PR TITLE
Feature: Obedience levels

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -105,6 +105,7 @@ void ClearFuryCutterDestinyBondGrudge(u8 battlerId);
 void HandleAction_RunBattleScript(void);
 u32 SetRandomTarget(u32 battlerId);
 u8 GetMoveTarget(u16 move, u8 setTarget);
+u8 GetBadgeCount(void);
 u8 IsMonDisobedient(void);
 u32 GetBattlerHoldEffect(u8 battlerId, bool32 checkNegating);
 u32 GetBattlerHoldEffectParam(u8 battlerId);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -1787,7 +1787,7 @@ static u8 CreateNPCTrainerParty(struct Pokemon *party, u16 trainerNum, bool8 fir
     s32 i, j;
     u8 monsCount;
     u8 fixedLvl = 1;
-    u8 baseLvl = 1;
+    u8 baseLvl = GetBadgeCount() * 10 + 5;
     u8 monLvl = 1;
     u16 evoSpecies = SPECIES_NONE;
     const struct TrainerMonNoItemDefaultMoves *noItemDefaultMovesData = gTrainers[trainerNum].party.NoItemDefaultMoves;
@@ -1888,7 +1888,7 @@ static u8 CreateNPCTrainerParty(struct Pokemon *party, u16 trainerNum, bool8 fir
             }
             personalityValue += nameHash << 8;
             fixedIV = fixedIV * 31 / 255;
-            monLvl = monLvl > fixedLvl ? monLvl : fixedLvl;
+            monLvl = max(monLvl, fixedLvl);
             do
             {
                 CreateMon(&party[i], evoSpecies, monLvl, fixedIV, TRUE, personalityValue, OT_ID_RANDOM_NO_SHINY, 0);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6018,16 +6018,6 @@ u8 GetMoveTarget(u16 move, u8 setTarget)
     return targetBattler;
 }
 
-static bool32 HasObedientBitSet(u8 battlerId)
-{
-    if (GetBattlerSide(battlerId) == B_SIDE_OPPONENT)
-        return TRUE;
-    if (GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES, NULL) != SPECIES_DEOXYS
-        && GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_SPECIES, NULL) != SPECIES_MEW)
-            return TRUE;
-    return GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_OBEDIENCE, NULL);
-}
-
 u8 GetBadgeCount()
 {
     u32 i;
@@ -6051,19 +6041,16 @@ u8 IsMonDisobedient(void)
     if (GetBattlerSide(gBattlerAttacker) == B_SIDE_OPPONENT)
         return 0;
 
-    if (HasObedientBitSet(gBattlerAttacker)) // only if species is Mew or Deoxys
-    {
-        if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && GetBattlerPosition(gBattlerAttacker) == 2)
-            return 0;
-        if (gBattleTypeFlags & BATTLE_TYPE_FRONTIER)
-            return 0;
-        if (gBattleTypeFlags & BATTLE_TYPE_RECORDED)
-            return 0;
-        if (FlagGet(FLAG_SYS_GAME_CLEAR))
-            return 0;
+    if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && GetBattlerPosition(gBattlerAttacker) == 2)
+        return 0;
+    if (gBattleTypeFlags & BATTLE_TYPE_FRONTIER)
+        return 0;
+    if (gBattleTypeFlags & BATTLE_TYPE_RECORDED)
+        return 0;
+    if (FlagGet(FLAG_SYS_GAME_CLEAR))
+        return 0;
 
-        obedienceLevel = 15 + (10 * GetBadgeCount());
-    }
+    obedienceLevel = 15 + (10 * GetBadgeCount());
 
     if (gBattleMons[gBattlerAttacker].level <= obedienceLevel)
         return 0;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6028,6 +6028,18 @@ static bool32 HasObedientBitSet(u8 battlerId)
     return GetMonData(&gPlayerParty[gBattlerPartyIndexes[battlerId]], MON_DATA_OBEDIENCE, NULL);
 }
 
+u8 GetBadgeCount()
+{
+    u32 i;
+    u8 badgeCount = 0;
+    for (i = FLAG_BADGE01_GET; i < FLAG_BADGE01_GET + NUM_BADGES; i++)
+    {
+        if (FlagGet(i))
+            badgeCount++;
+    }
+    return badgeCount;
+}
+
 u8 IsMonDisobedient(void)
 {
     s32 rnd;
@@ -6047,19 +6059,10 @@ u8 IsMonDisobedient(void)
             return 0;
         if (gBattleTypeFlags & BATTLE_TYPE_RECORDED)
             return 0;
-        if (!IsOtherTrainer(gBattleMons[gBattlerAttacker].otId, gBattleMons[gBattlerAttacker].otName))
-            return 0;
-        if (FlagGet(FLAG_BADGE08_GET))
+        if (FlagGet(FLAG_SYS_GAME_CLEAR))
             return 0;
 
-        obedienceLevel = 10;
-
-        if (FlagGet(FLAG_BADGE02_GET))
-            obedienceLevel = 30;
-        if (FlagGet(FLAG_BADGE04_GET))
-            obedienceLevel = 50;
-        if (FlagGet(FLAG_BADGE06_GET))
-            obedienceLevel = 70;
+        obedienceLevel = 15 + (10 * GetBadgeCount());
     }
 
     if (gBattleMons[gBattlerAttacker].level <= obedienceLevel)


### PR DESCRIPTION
### Description
Implementation of obedience based on number of badges.
Before beating the Elite Four, player owned mons will obey only if their levels match the following formula: 

    mon_level <= (num_of_gyms_defeated * 10 + 15)

**NOTE**: In vanilla Emerald, the game only check for obedience of traded mons. Here it apllies to **ALL** mons, not only traded.

Also, min level of NPC mons will be based on badges obtained as well:

    npc_mon_min_level = num_of_gyms_defeated * 10 + 5


### Proposed changes
<!--- List the changes you are making. Mark them as you get them done. -->
- [x] Implement obedience based on number of badges.
- [x] Set min level of NPC trainers based on number of badges.
